### PR TITLE
Pre-filled in subscription name

### DIFF
--- a/website/subscriptions/views.py
+++ b/website/subscriptions/views.py
@@ -192,7 +192,8 @@ class RequestView(TemplateView):
         :param kwargs: keyword arguments
         :return: the request.html page
         """
-        form = RequestForm(None)
+        prefilled_subscription = request.GET.get("subscription", "")
+        form = RequestForm(initial={"subscription_name": prefilled_subscription})
         context = {"form": form}
         return render(request, self.template_name, context)
 


### PR DESCRIPTION
When clicking "This subscription is not known to us" a redirect to the subscription request form will take place and the subscription inputted in the search field will now be automatically filled in as name.