### PR TITLE
Fix for button on enter details page

### DIFF
--- a/website/users/static/users/js/details.js
+++ b/website/users/static/users/js/details.js
@@ -65,4 +65,5 @@ function register_keyup() {
 jQuery(document).ready(function($) {
 	register_keyup();
 	putback_details();
+	update();
 });


### PR DESCRIPTION
A fix for the next button not appearing on the enter information page.