### PR TITLE
Set cookies in response instead of erasing in Javascript

### DIFF
--- a/website/mail/templates/mail/verification_send.html
+++ b/website/mail/templates/mail/verification_send.html
@@ -23,11 +23,3 @@
         {% endif %}
     </div>
 {% endblock %}
-{% if succeeded %}
-    {% block js %}
-        <script src="{% static 'kanikervanaf/js/general.js' %}"></script>
-        <script>
-            eraseAll();
-        </script>
-    {% endblock %}
-{% endif %}

--- a/website/subscriptions/views.py
+++ b/website/subscriptions/views.py
@@ -220,7 +220,10 @@ def verification_send(request):
             verification_url,
             request,
         ):
-            return HttpResponseRedirect(reverse("mail:verification_send_succeeded"))
+            response = HttpResponseRedirect(reverse("mail:verification_send_succeeded"))
+            response.delete_cookie("subscription_details")
+            response.delete_cookie("subscription_items")
+            return response
         else:
             mail_list.user_information.delete()
             mail_list.delete()


### PR DESCRIPTION
Reset the subscriptions details cookie and items cookie in the response of a request instead of doing it in javascript.

Closes #74 