### PR TITLE
Mail template base fix

### DIFF
--- a/website/users/templates/email/email_confirmation.html
+++ b/website/users/templates/email/email_confirmation.html
@@ -1,4 +1,4 @@
-{% extends "email/mail_base.html" %}
+{% extends "email/email.html" %}
 
 {% block title %}Email bevestigen{% endblock %}
 

--- a/website/users/templates/email/password_reset.html
+++ b/website/users/templates/email/password_reset.html
@@ -1,4 +1,4 @@
-{% extends "email/mail_base.html" %}
+{% extends "email/email.html" %}
 
 {% block title %}Wachtwoord vergeten{% endblock %}
 


### PR DESCRIPTION
Fixes an issue where the password reset email and the confirmation email resulted in a 500 error as the mail base template was not renamed.